### PR TITLE
Updated script to properly support locations of jars for hadoop-2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,10 +4,24 @@
 #
 # opentsdb must be installed, either using .rpm or "make install" after building it
 
-HADOOP_HOME=/opt/mapr/hadoop/hadoop-0.20.2
-# On RPM based OSes it's usually in /usr/share/opentsdb
-# On Deb based OSes it's usually in /usr/local/share/opentsdb
-OPENTSDB_HOME=/usr/share/opentsdb
+# Go with the first hadoop found in /opt/mapr/hadoop
+HADOOP_HOME=$(find /opt/mapr/hadoop -maxdepth 1 -type d -name "hadoop-*" | head -1)
+
+OPENTSDB_HOME=''
+
+if [[ -d "/usr/share/opentsdb" ]]
+then
+    OPENTSDB_HOME=/usr/share/opentsdb
+elif [[ -d "/usr/local/share/opentsdb" ]]
+then
+    OPENTSDB_HOME=/usr/local/share/opentsdb
+fi
+
+if [[ $OPENTSDB_HOME -eq '' ]]
+then
+    echo "OpenTSDB not found on this host please edit this script and set it."
+    exit 1
+fi
 
 #******************************************
 # first check if required folders are available
@@ -21,6 +35,8 @@ test -d "$OPENTSDB_HOME" || {
   echo >&2 "'$OPENTSDB_HOME' doesn't exist, is openTSDB installed?"
   exit 1
 }
+
+echo "Using Hadoop libraries found in ${HADOOP_HOME}"
 #******************************************
 # link the necessary jars from $HADOOP_HOME to OPENTSDB_HOME/lib
 # Base of MapR installation


### PR DESCRIPTION
The script was only looking in the `$HADOOP_HOME/lib` directory, which is the location for the libs when `HADOOP_HOME` was set to hadoop-0.20.2, but with hadoop-2.4.1 the jars are in `/opt/mapr/hadoop/hadoop-2.4.1/share/hadoop/common` and `/opt/mapr/hadoop/hadoop-2.4.1/share/hadoop/common/lib`. This was causing the `install.sh` script to miss a lot of necessary jars.

I'm using `find $HADOOP_LIB_DIR -name "*.jar" to get all the jars needed.

I've also changed the copy command to a soft link.
