### PR TITLE
Update install.sh for MapR v5.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,10 @@ done
 
 VERSION=`cat /opt/mapr/MapRBuildVersion`
 
-if [[ $VERSION == 5.* ]]; then
+if [[ $VERSION == 5.2 ]]; then
+  echo "MapR 5.2 installed. Downloading asynchbase-1.7.0"
+  async_link=http://repository.mapr.com/nexus/content/groups/mapr-public/org/hbase/asynchbase/1.7.0-mapr-1607/asynchbase-1.7.0-mapr-1607.jar
+elif [[ $VERSION == 5.* ]]; then
   echo "MapR 5.x installed. Downloading asynchbase 1.6.0"
   async_link=http://repository.mapr.com/nexus/content/groups/mapr-public/org/hbase/asynchbase/1.6.0-mapr-1503/asynchbase-1.6.0-mapr-1503.jar
 elif [[ $VERSION == 4.1.* ]]; then


### PR DESCRIPTION
For MapR v5.2 it is necessary to link with http://repository.mapr.com/nexus/content/groups/mapr-public/org/hbase/asynchbase/1.7.0-mapr-1607/asynchbase-1.7.0-mapr-1607.jar